### PR TITLE
Add a `share by email` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 Private Family Law - Child Arrangements Information Tool
 
-## PRIVATE REPO
-
-**This repo is private until the service reaches public beta.**
-
-The service will not go into public beta until there is confidence that the guidance/information contained in the service is accurate.
-
-That confidence is dependent upon sign off by Policy and Legal (and confirmation that the service is not at odds with any ministerial steer).
-
 ## Pre-requisites
 
   [Node 8.4.0](https://nodejs.org)

--- a/app/assets/images/icon-email.svg
+++ b/app/assets/images/icon-email.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 25.5 25.5" style="enable-background:new 0 0 25.5 25.5;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#005EA5;}
+	.st1{fill:#FFFFFF;}
+</style>
+<rect class="st0" width="25.5" height="25.5"/>
+<g id="email">
+	<g id="Social-media" transform="translate(-549.000000, -673.000000)">
+		<g id="Group-13" transform="translate(549.000000, 671.000000)">
+			<path id="Page-1-Copy-2" class="st1" d="M4.5,20.5H21V9H4.5V20.5z M7.9,10.8h9.7L12.8,15L7.9,10.8z M19.2,11.9v6.7H6.4v-6.7
+				l6.4,5.5L19.2,11.9z"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/app/components/ShareLink/ShareLink--print.pcss
+++ b/app/components/ShareLink/ShareLink--print.pcss
@@ -1,0 +1,5 @@
+@import 'utils/_app.pcss';
+
+.ShareLink {
+  display: none;
+}

--- a/app/components/ShareLink/ShareLink.njk
+++ b/app/components/ShareLink/ShareLink.njk
@@ -1,0 +1,18 @@
+{% macro ShareLink(name) %}
+  {% set pageName = getBlockProp(name, 'heading') | lower %}
+  {% set link     = (req.servername + getRouteUrl(name)) + '?utm_source=share' %}
+
+  {% set subject = ('I want to share this page about ' + pageName + ' with you') | urlencode %}
+  {% set lede    = getBlockProp(name, 'lede') | urlencode %}
+  {% set footer  = ('Find out more about ' + pageName + ' on this page: ' + link) | urlencode %}
+
+  {% if getBlockProp(name, 'lede_additional') %}
+    {% set lede = lede + '%0D%0A' + (getBlockProp(name, 'lede_additional') | urlencode) %}
+  {% endif %}
+
+  {% set body = lede + '%0D%0A%0D%0A' + footer %}
+
+  <div class="ShareLink">
+    <a href="mailto:?to=&body={{ body }}&subject={{ subject }}">Share this page by email</a>
+  </div>
+{% endmacro %}

--- a/app/components/ShareLink/ShareLink.pcss
+++ b/app/components/ShareLink/ShareLink.pcss
@@ -1,0 +1,23 @@
+@import 'utils/_app.pcss';
+
+div.ShareLink {
+  background-color: var(--govuk-blue);
+  padding: 0.5rem;
+}
+
+.ShareLink a {
+  font-size: 16px;
+  background: url('/public/images/icon-email.svg') no-repeat;
+  background-size: 22px 22px;
+  color: var(--govuk-white);
+  padding-left: 25px;
+}
+
+@media (min-width: 641px) {
+  div.ShareLink {
+    position: relative;
+    margin-top: -5.5rem;
+    padding: 1rem;
+    top: 0;
+  }
+}

--- a/app/templates/app/app.html
+++ b/app/templates/app/app.html
@@ -11,7 +11,8 @@
   "components/SectionResources/SectionResources.njk",
   "components/SectionVideo/SectionVideo.njk",
   "components/Step/Step.njk",
-  "components/Step/FmcStep.njk"
+  "components/Step/FmcStep.njk",
+  "components/ShareLink/ShareLink.njk"
 ]) }}
 
 {% block page_title %}{{ getFormattedProp(route.id, 'heading') }}{% if route.id != 'route:index' %} - {{ getFormattedProp('route:summary', 'heading') }}{% endif %}{% endblock %}

--- a/app/templates/app/app.pcss
+++ b/app/templates/app/app.pcss
@@ -3,6 +3,7 @@
 @import 'Costs/Costs.pcss';
 @import 'FeedbackSimplified/FeedbackSimplified.pcss';
 @import 'RevealingContent/RevealingContent.pcss';
+@import 'ShareLink/ShareLink.pcss';
 
 .disqualified #global-cookie-message {
   display: none !important;

--- a/app/templates/area/area.html
+++ b/app/templates/area/area.html
@@ -25,6 +25,9 @@
   </div>
 
   <div class="{{ govukClassname('column-one-third') }}">
+    {% if route.shareable %}
+    {{ Block.ShareLink(route.id) }}
+    {% endif %}
     {{ Block.ProsCons(route.id, modifier='header', level=2) }}
   </div>
 </div>

--- a/metadata/blocks/en/route:collaborative_law.json
+++ b/metadata/blocks/en/route:collaborative_law.json
@@ -32,5 +32,6 @@
   "summary_lede": "!route:collaborative_law#lede!",
   "title": "",
   "url": "/collaborative-law",
-  "usp": "You can still communicate with the other parent but may have complex legal issues to resolve."
+  "usp": "You can still communicate with the other parent but may have complex legal issues to resolve.",
+  "shareable": true
 }

--- a/metadata/blocks/en/route:lawyer_negotiation.json
+++ b/metadata/blocks/en/route:lawyer_negotiation.json
@@ -26,5 +26,6 @@
   "summary_lede": "!route:lawyer_negotiation#lede!",
   "title": "",
   "url": "/lawyer-negotiation",
-  "usp": "Your relationship is still difficult and you’d prefer not to meet, or there’s a lack of trust."
+  "usp": "Your relationship is still difficult and you’d prefer not to meet, or there’s a lack of trust.",
+  "shareable": true
 }

--- a/metadata/blocks/en/route:negotiating_between_parents.json
+++ b/metadata/blocks/en/route:negotiating_between_parents.json
@@ -26,5 +26,6 @@
   "summary_lede": "!route:negotiating_between_parents#lede!",
   "title": "",
   "url": "/negotiating-between-parents",
-  "usp": "You both still communicate and agree on the majority of issues but may benefit from using a tool such as a parenting plan."
+  "usp": "You both still communicate and agree on the majority of issues but may benefit from using a tool such as a parenting plan.",
+  "shareable": true
 }

--- a/metadata/blocks/en/route:professional_mediation.json
+++ b/metadata/blocks/en/route:professional_mediation.json
@@ -34,5 +34,6 @@
   "summary_lede": "Mediation sessions are run by professionals who help you try to reach an agreement without going to court. It isn’t relationship counselling and you don’t have to be in the same room as the other parent.",
   "title": "",
   "url": "/professional-mediation",
-  "usp": "You both want to reach an agreement but need help from someone who is independent."
+  "usp": "You both want to reach an agreement but need help from someone who is independent.",
+  "shareable": true
 }


### PR DESCRIPTION
This is another experiment, and for now is a low-cost solution meaning
just a `mailto:` link, in some of the `Reaching an agreement` sections.