### PR TITLE
Updates to work on live-1 cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:10.15.2
 
 # Create app directory
-RUN mkdir -p /usr/app
-WORKDIR /usr/app
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
 
-ENV PATH=/usr/app/node_modules/.bin:$PATH
+ENV PATH=/usr/src/app/node_modules/.bin:$PATH
 
 # Install node modules
 COPY package.json yarn.lock ./
@@ -17,6 +17,13 @@ RUN yarn build
 
 COPY metadata ./metadata
 
+# Add application user
+ENV APPUSER moj
+ENV APPUID 1001
+
+RUN adduser $APPUSER --disabled-password --gecos "" -u $APPUID \
+    && chown -R $APPUSER:$APPUSER ./public
+
 ARG APP_BUILD_DATE
 ENV APP_BUILD_DATE ${APP_BUILD_DATE}
 
@@ -28,6 +35,8 @@ ENV APP_GIT_COMMIT ${APP_GIT_COMMIT}
 
 ARG APP_VERSION
 ENV APP_VERSION ${APP_VERSION}
+
+USER $APPUID
 
 EXPOSE 3000
 ENTRYPOINT ["yarn", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,12 @@
+# Simplify running the application inside a container locally.
+# Usage: `docker-compose up`
+#
+# Do not use docker-compose in production environments.
+#
 version: '3'
 
 services:
   web:
     build: .
-    volumes:
-      - .:/usr/app
     ports:
       - "3000:3000"

--- a/lib/server.js
+++ b/lib/server.js
@@ -61,7 +61,7 @@ const screenUsers = (ENV) => {
     }
     // redirect staging to new k8s cluster
     if (req.get('Host').includes('cait-staging.herokuapp.com')) {
-      return res.redirect(301, 'https://fj-cait-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io')
+      return res.redirect(301, 'https://fj-cait-staging.apps.live-1.cloud-platform.service.justice.gov.uk')
     }
     if (!req.url.match(allowedRegex)) {
       let campaignName


### PR DESCRIPTION
We need to make some changes to the Dockerfile in order for the
application to work in the new K8s live-1 cluster.

In Live-1, the Cloud Platform team introduced Pod Security Policies,
to tighten the security on this production cluster.

The main impact of this restricted policy is that it prevents
pods/containers from running as the root user.