### PR TITLE
Update CircleCI to work with Live-1 k8s cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - run:
           name: push docker image
           command: |
-            login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            login="$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
             ${login}
 
             docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
@@ -95,7 +95,7 @@ jobs:
 
             kubectl set image -n fj-cait-staging \
                     deployment/fj-cait-deployment-staging \
-                    fj-cait-web-staging="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+                    webapp="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
 
             kubectl annotate -n fj-cait-staging \
                     deployment/fj-cait-deployment-staging \
@@ -112,7 +112,7 @@ jobs:
       - run:
           name: promote staging image to production
           command: |
-            login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            login="$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
             ${login}
 
             docker pull "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
@@ -141,7 +141,7 @@ jobs:
 
             kubectl set image -n fj-cait-production \
                     deployment/fj-cait-deployment-production \
-                    fj-cait-web-production="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+                    webapp="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
 
             kubectl annotate -n fj-cait-production \
                     deployment/fj-cait-deployment-production \


### PR DESCRIPTION
We had hardcoded the AWS region, and in live-1 this has to change from `eu-west-1` to `eu-west-2`. So better to use the ENV variable already exposed.

Also, for consistency, we are going to name the container in all applications the same (`webapp`) as it makes it easier to work with when there are multiple containers (like another one running nginx).