### PR TITLE
Fix comparison table grid system

### DIFF
--- a/app/css/fullsize.css
+++ b/app/css/fullsize.css
@@ -1,0 +1,1 @@
+@import 'fullsize/fullsize.pcss';

--- a/app/templates/app/app.pcss
+++ b/app/templates/app/app.pcss
@@ -1,7 +1,6 @@
 @import 'utils/app-base.pcss';
 @import 'ProsCons/ProsCons.pcss';
 @import 'Costs/Costs.pcss';
-@import 'ComparisonTable/ComparisonTable.pcss';
 @import 'FeedbackSimplified/FeedbackSimplified.pcss';
 @import 'RevealingContent/RevealingContent.pcss';
 @import 'ShareLink/ShareLink.pcss';

--- a/app/templates/fullsize/fullsize.html
+++ b/app/templates/fullsize/fullsize.html
@@ -9,10 +9,9 @@
 <div class="{{ govukClassname('grid-row') }}">
     <div class="{{ govukClassname('column-full') }}">
         {{ Block.PageHeader(route.id, heading_size='xlarge') }}
+        {{ Block.Group(blocks=route.blocks) }}
     </div>
 </div>
-
-{{ Block.Group(blocks=route.blocks) }}
 
 <nav class="AreaLinks" data-block-name="{{ collection }}">
     <div class="AreaLinks__overview">

--- a/app/templates/fullsize/fullsize.html
+++ b/app/templates/fullsize/fullsize.html
@@ -1,0 +1,23 @@
+{% extends 'templates/about/about.html' %}
+
+{% block stylesheet %}
+{{ super() }}
+<link href="{{ asset_path }}stylesheets/fullsize.css" media="screen" rel="stylesheet">
+{% endblock %}
+
+{% block grid_content %}
+<div class="{{ govukClassname('grid-row') }}">
+    <div class="{{ govukClassname('column-full') }}">
+        {{ Block.PageHeader(route.id, heading_size='xlarge') }}
+    </div>
+</div>
+
+{{ Block.Group(blocks=route.blocks) }}
+
+<nav class="AreaLinks" data-block-name="{{ collection }}">
+    <div class="AreaLinks__overview">
+        <h3 class="AreaLinks__overview__heading {{ govukClassname('gv-u-heading-large') }}">{{ Block.String('AreaLinks__overview__heading') }}</h3>
+        <p><a href="{{ getRouteUrl('route:summary') }}" class="AreaLinks__overview__link" data-link-type="site-nav">{{ Block.String('AreaLinks__overview__link') }}</a></p>
+    </div>
+</nav>
+{% endblock %}

--- a/app/templates/fullsize/fullsize.pcss
+++ b/app/templates/fullsize/fullsize.pcss
@@ -3,3 +3,7 @@
 .gv-o-grid-item {
   padding: 0;
 }
+
+.govuk-width-container {
+  padding-top: 2rem;
+}

--- a/app/templates/fullsize/fullsize.pcss
+++ b/app/templates/fullsize/fullsize.pcss
@@ -1,0 +1,5 @@
+@import 'ComparisonTable/ComparisonTable.pcss';
+
+.gv-o-grid-item {
+  padding: 0;
+}

--- a/metadata/blocks/en/route:comparison_table.json
+++ b/metadata/blocks/en/route:comparison_table.json
@@ -1,7 +1,7 @@
 {
   "_blockType": "Route",
   "_id": "route:comparison_table",
-  "_isa": "view:about",
+  "_isa": "view:fullsize",
   "blocks": [
     "comparison-table"
   ],

--- a/metadata/blocks/en/view:fullsize.json
+++ b/metadata/blocks/en/view:fullsize.json
@@ -1,0 +1,7 @@
+{
+  "_blockType": "View",
+  "_id": "view:fullsize",
+  "breadcrumbs": true,
+  "static": true,
+  "template": "fullsize"
+}


### PR DESCRIPTION
We must use a new template, as existing ones are all based on a `two-thirds` grid, making the table cut on desktops and not fully expanding the whole width of the page.

I've called this new template `fullsize`.

<img width="525" alt="Screen Shot 2019-06-07 at 10 57 11" src="https://user-images.githubusercontent.com/687910/59096583-128b1700-8913-11e9-924d-ea6d5853630c.png">
