### PR TITLE
Ignore unused image assets requests

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,12 @@ if (flags.unavailable) {
   unavailableJson = require(path.join(__dirname, `../metadata/blocks/en/${flags.unavailableId}.json`))
 }
 
+// Stop some assets we don't even use from raising 404 (bots/crawlers)
+// The few icons we use are SVG and will bypass this
+router.get(/\/images\/icon-.*\.png$/, (req, res) => {
+  return res.status(200).send()
+})
+
 const validateHealthcheck = html => {
   const indexMatch = new RegExp(`<h1[^>]*>${indexJson.heading}</h1>`)
   return !!html.match(indexMatch)


### PR DESCRIPTION
This seems to be the result of some kind of bot or crawler, but every 3 days, our logs get full of 404 due to requests to image assets we don't use in this project.

This is usually not a problem, but we've setup some prometheus alerts that gets triggered easily when this huge amount of 404 errors happen in a short amount of time (seconds).

With this small workaround we are going to "ignore" (returning an early 200 response) these requests to these specific assets. Any other asset is not affected.

<img width="929" alt="Screen Shot 2019-07-05 at 16 22 49" src="https://user-images.githubusercontent.com/687910/60820270-08ba3500-a199-11e9-904b-403f96f037cf.png">

<img width="1021" alt="Screen Shot 2019-07-08 at 14 37 03" src="https://user-images.githubusercontent.com/687910/60820287-1079d980-a199-11e9-8ae3-9641f2930cd6.png">
