### PR TITLE
Stop using `circleci` branch of cloud-platform/tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ references:
           ENV: test
   cloud_container: &cloud_container
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      - image: ${ECR_ENDPOINT}/cloud-platform/tools:1.21
         environment:
           GITHUB_TEAM_NAME_SLUG: family-justice
 


### PR DESCRIPTION
As per conversation here:
https://mojdt.slack.com/archives/CH6D099DF/p1601893835012800
and
https://mojdt.slack.com/archives/C57UPMZLY/p1601904387244600

The `circleci` is no longer maintained and is recommended to use the main branch on the tools repo.

Note: this is actually a "try and error" PR, as it might not work without further changes, but we need to merge this to see what happens...