### PR TITLE
Revert back cloud container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ references:
           ENV: test
   cloud_container: &cloud_container
     docker:
-      - image: ministryofjustice/cloud-platform-tools:1.21
+      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
         environment:
           GITHUB_TEAM_NAME_SLUG: family-justice
 


### PR DESCRIPTION
For the time being, revert this back to how was it.

Cloud Platforms will be making some updates to the docker image and we can try again when they do. At the moment it is a bit rough and untested.

Follow-up conversation:
https://mojdt.slack.com/archives/C57UPMZLY/p1601904387244600