### PR TITLE
Mitigate a redirection vulnerability

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -62,13 +62,23 @@ const screenUsers = (ENV) => {
   // generic handling
   const allowedRegex = /\.[^.]{2,3}(\?[^?]+){0,1}$/
   router.use((req, res, next) => {
+    // Avoid double slashes by merging 2 or more into one, before continuing
+    // with the following rules. This mitigates a redirection vulnerability.
+    // Examples:
+    //   service.com//google.co.uk/ -> service.com/google.co.uk/
+    //   service.com/a//b/c///d/ -> service.com/a/b/c/d/
+    //
+    req.url = req.url.replace(/\/+/g, '/')
+
     if (req.connection.remoteAddress.includes('127.0.0.1')) {
       return next()
     }
+
     // redirect staging to new k8s cluster
     if (req.get('Host').includes('cait-staging.herokuapp.com')) {
       return res.redirect(301, 'https://fj-cait-staging.apps.live-1.cloud-platform.service.justice.gov.uk')
     }
+
     if (!req.url.match(allowedRegex)) {
       let campaignName
       let landing

--- a/lib/server.js
+++ b/lib/server.js
@@ -64,9 +64,14 @@ const screenUsers = (ENV) => {
   router.use((req, res, next) => {
     // Avoid double slashes by merging 2 or more into one, before continuing
     // with the following rules. This mitigates a redirection vulnerability.
+    //
+    // Note: `req.url` contains the path, not the full URL (despite its name),
+    // also, after the rewrite, `req.originalUrl` will keep the original path.
+    // https://expressjs.com/en/api.html#req.originalUrl
+    //
     // Examples:
-    //   service.com//google.co.uk/ -> service.com/google.co.uk/
-    //   service.com/a//b/c///d/ -> service.com/a/b/c/d/
+    //   //google.co.uk/ -> service.com/google.co.uk/
+    //   /a//b/c///d/ -> service.com/a/b/c/d/
     //
     req.url = req.url.replace(/\/+/g, '/')
 


### PR DESCRIPTION
Ticket: https://trello.com/c/9VDqIYdW

This is a bit dirty but will do the work until maybe a more solid solution is found (deep in the framework we are using which is the seed of what is now Form Builder).

Essentially, we rewrite the url by squishing 2 or more slashes `/` into just one, thus eliminating the redirection issue. It will just return a 404 not found page.