### PR TITLE
Hide from search engines the comparison table

### DIFF
--- a/app/templates/app/app.html
+++ b/app/templates/app/app.html
@@ -21,6 +21,9 @@
 {% block head %}
 {{ super() }}
 <meta name="google-site-verification" content="Ed6XKLFCCovwl_3gUpR5owg8AvgINOhiWWNGeJhHyio"/>
+{% if route.id == 'route:comparison_table' %}
+<meta name="robots" content="noindex, nofollow"/>
+{% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This was a prototype/experiment long time ago but it is not complete and it lacks some information.

As per PM request, avoid this being indexed by search engines until we update the table.