### PR TITLE
Add google optimize script tag

### DIFF
--- a/app/templates/app/app.html
+++ b/app/templates/app/app.html
@@ -18,6 +18,12 @@
 
 {% block page_title %}{{ getFormattedProp(route.id, 'heading') }}{% if route.id != 'route:index' %} - {{ getFormattedProp('route:summary', 'heading') }}{% endif %}{% endblock %}
 
+{# Everything in this block will be injected as high as possible in the HEAD tag #}
+{% block stylesheet %}
+<script src="https://www.googleoptimize.com/optimize.js?id=OPT-PJSMHMK"></script>
+{{ super() }}
+{% endblock %}
+
 {% block head %}
 {{ super() }}
 <meta name="google-site-verification" content="Ed6XKLFCCovwl_3gUpR5owg8AvgINOhiWWNGeJhHyio"/>


### PR DESCRIPTION
Ticket: https://trello.com/c/kOng50jf

This is for now a proof of concept. In essence it works in a very similar way to google tag manager.
Nothing visible yet, WIP.

The installation recommends the script to be added at the top of the `<HEAD>` tag. Thus, using the stylesheet block, that gets rendered inside the HEAD.