### PR TITLE
Bump node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 references:
   app_containers: &app_containers
     docker:
-      - image: circleci/node:12.12.0
+      - image: circleci/node:12.22.6
         environment:
           ENV: test
   cloud_container: &cloud_container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.12.0
+FROM node:12.22.6
 
 # Create app directory
 RUN mkdir -p /usr/src/app

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Private Family Law - Child Arrangements Information Tool
 
 ```
 brew install nvm
-nvm install 12.12.0
+nvm install 12.22.6
 ```
 
   [Node Version Manager](https://github.com/nvm-sh/nvm)
 
-  [Node 12.12.0](https://nodejs.org)
+  [Node 12.22.6](https://nodejs.org)
 
   [Yarn >= 1.12](https://yarnpkg.com)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pflr-cait",
   "version": "1.12.0",
   "engines": {
-    "node": "^12.12.0"
+    "node": "^12.22.6"
   },
   "main": "lib/start.js",
   "repository": {},


### PR DESCRIPTION
Ticket: https://trello.com/c/OOAZmb6D

A vulnerability has been found on multiple `Node.js` versions.

Bump to the latest version on the 12.x branch, that fixes/mitigates the issue.

More info:
https://github.blog/2021-09-08-github-security-update-vulnerabilities-tar-npmcli-arborist/